### PR TITLE
When using an architecture that aims to enforce

### DIFF
--- a/internal/codegen/golang/opts/override.go
+++ b/internal/codegen/golang/opts/override.go
@@ -106,8 +106,8 @@ func (o *Override) parse(req *plugin.GenerateRequest) (err error) {
 		return fmt.Errorf("Override specifying both `column` (%q) and `func_name` (%q) is not valid", o.Column, o.FuncName)
 	case o.DBType != "" && o.FuncName != "":
 		return fmt.Errorf("Override specifying both `db_type` (%q) and `func_name` (%q) is not valid", o.DBType, o.FuncName)
-	case o.Column == "" && o.DBType == "" && o.FuncName == "":
-		return fmt.Errorf("Override must specify one of either `column` or `db_type`")
+	case o.Column == "" || o.DBType == "" || o.FuncName == "":
+		return fmt.Errorf("Override must specify one of the following: `column` or `db_type` or `func_name`")
 	}
 
 	// validate Column

--- a/internal/codegen/golang/opts/override.go
+++ b/internal/codegen/golang/opts/override.go
@@ -20,6 +20,7 @@ type Override struct {
 	// fully qualified name of the Go type, e.g. `github.com/segmentio/ksuid.KSUID`
 	DBType                  string `json:"db_type" yaml:"db_type"`
 	Deprecated_PostgresType string `json:"postgres_type" yaml:"postgres_type"`
+	FuncName                string `json:"func_name" yaml:"func_name"`
 
 	// for global overrides only when two different engines are in use
 	Engine string `json:"engine,omitempty" yaml:"engine"`
@@ -100,8 +101,12 @@ func (o *Override) parse(req *plugin.GenerateRequest) (err error) {
 	// validate option combinations
 	switch {
 	case o.Column != "" && o.DBType != "":
-		return fmt.Errorf("Override specifying both `column` (%q) and `db_type` (%q) is not valid.", o.Column, o.DBType)
-	case o.Column == "" && o.DBType == "":
+		return fmt.Errorf("Override specifying both `column` (%q) and `db_type` (%q) is not valid", o.Column, o.DBType)
+	case o.Column != "" && o.FuncName != "":
+		return fmt.Errorf("Override specifying both `column` (%q) and `func_name` (%q) is not valid", o.Column, o.FuncName)
+	case o.DBType != "" && o.FuncName != "":
+		return fmt.Errorf("Override specifying both `db_type` (%q) and `func_name` (%q) is not valid", o.DBType, o.FuncName)
+	case o.Column == "" && o.DBType == "" && o.FuncName == "":
 		return fmt.Errorf("Override must specify one of either `column` or `db_type`")
 	}
 

--- a/internal/codegen/golang/query.go
+++ b/internal/codegen/golang/query.go
@@ -11,6 +11,7 @@ import (
 
 type QueryValue struct {
 	Emit        bool
+	EmitAsArg   bool
 	EmitPointer bool
 	Name        string
 	DBName      string // The name of the field in the database. Only set if Struct==nil.
@@ -25,6 +26,10 @@ type QueryValue struct {
 
 func (v QueryValue) EmitStruct() bool {
 	return v.Emit
+}
+
+func (v QueryValue) EmitStructAsArg() bool {
+	return v.EmitAsArg
 }
 
 func (v QueryValue) IsStruct() bool {
@@ -248,7 +253,7 @@ func (v QueryValue) VariableForField(f Field) string {
 	if !v.IsStruct() {
 		return v.Name
 	}
-	if !v.EmitStruct() {
+	if !v.EmitStructAsArg() {
 		return toLowerCase(f.Name)
 	}
 	return v.Name + "." + f.Name


### PR DESCRIPTION
When using an architecture that aims to enforce
dependency inversion, such as onion, it is very
useful for the data layer to look inwardly to
the domain and use entities from within.

Before this change, SQLc had the capability to
look to different packages for predefined types
for column types only. This change allows for
functions to receive predefined types as arguments and return them.

This commit is the first cut of this idea, so it
lacks finesse. One downside is that there is no
capability to use predefined column types in Go
and the new predefined func_name types provided
by this commit.